### PR TITLE
Use SessionDuration attribute to support SSO sessions of any length

### DIFF
--- a/aws_jumpcloud/saml.py
+++ b/aws_jumpcloud/saml.py
@@ -6,6 +6,7 @@ SAMLRole = namedtuple("SAMLRole", ["role_arn", "principal_arn"])
 
 
 def get_assertion_roles(saml_assertion_xml):
+    # Returns a list of AWS roles that the assertion says may be assumed.
     soup = BeautifulSoup(saml_assertion_xml, "lxml-xml")
     assertion_tag = soup.find("Assertion")
     assert(assertion_tag is not None)
@@ -22,3 +23,18 @@ def get_assertion_roles(saml_assertion_xml):
         assert(principal_arn.startswith("arn:aws:iam::"))
         saml_roles.append(SAMLRole(role_arn, principal_arn))
     return saml_roles
+
+
+def get_assertion_duration(saml_assertion_xml):
+    # Returns the SAML assertion's SessionDuration attribute, in seconds.
+    soup = BeautifulSoup(saml_assertion_xml, "lxml-xml")
+    assertion_tag = soup.find("Assertion")
+    assert(assertion_tag is not None)
+    attr_tag = assertion_tag.find(
+        "Attribute", attrs={"Name": "https://aws.amazon.com/SAML/Attributes/SessionDuration"})
+    if attr_tag is None:
+        return None
+    else:
+        value_tag = attr_tag.find("AttributeValue")
+        assert(value_tag is not None)
+        return int(value_tag.text)


### PR DESCRIPTION
Previously we were hardcoding the timespan of each temporary session token to
1 hour. But JumpCloud's SAML assertion usually contains a `SessionDuration`
attribute, which can be any length of time up to 12 hours. This change inspects
the XML for the `SessionDuration` and uses that to support whatever duration is
in the JumpCloud SSO configuration.

For Guild, the upshot is that security tokens will only need to be refreshed
after 12 hours, rather than after 1 hour.