### PR TITLE
Fix bug that required iam:ListAccountAliases permission

### DIFF
--- a/aws_jumpcloud/aws.py
+++ b/aws_jumpcloud/aws.py
@@ -71,12 +71,6 @@ def assume_role_with_saml(saml_role, saml_assertion_xml):
 
 
 def get_account_alias(session):
-    client = boto3.client("iam", aws_access_key_id=session.access_key_id,
-                          aws_secret_access_key=session.secret_access_key,
-                          aws_session_token=session.session_token)
-    resp = client.list_account_aliases()
-    assert(resp['ResponseMetadata']['HTTPStatusCode'] == 200)
-    return resp['AccountAliases'][0] if resp['AccountAliases'] else None
     try:
         client = boto3.client("iam", access_key_id=session.access_key_id,
                               secret_access_key=session.secret_access_key,


### PR DESCRIPTION
`get_account_alias()` is supposed to be resilient because the alias isn't actually _required_ for `aws-jumpcloud rotate`/`exec`. We only need the alias so that we can have a pretty name displayed for the "AWS Account" column of `aws-jumpcloud list`.

Lines 80-89 had the resilient version of this function -- a `try`/`except` block that just ignores any exceptions. But somehow the same code from lines 81-86 was also present above that. Maybe a Git merge error?