### PR TITLE
Optionally provide the URL as a command line param to "aws-jumpcloud add"

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,39 @@ aws-jumpcloud exec duff -- true && eval "$(aws-jumpcloud export duff)"
 ```
 
 
+### Adding a profile with an assumed role
+
+You may find that you need to interact with AWS using a different IAM role than the one connected to JumpCloud. For example, your JumpCloud integration may only grant read-only access to resources in the AWS Console, and you need to assume an expanded role in order to make changes. Or, if your company has more than one AWS account, you may login to a single AWS account, and then assume a role in another account to access the resources in that account.
+
+`aws-jumpcloud` profiles can be configured to automatically assume another IAM role when you establish a session. Each time you establish a new AWS session using such a profiles, `aws-jumpcloud` will login through JumpCloud, and then immediately call the [AssumeRole API](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) to request credentials for the other role. The role can be in your own AWS account or in another AWS account.
+
+To configure a profile to assume a role on each login, add the `--role` parameter to the `aws-jumpcloud add` command. Here's an example of assuming a role in the same account:
+
+```
+$ aws-jumpcloud add --role=deployer duff-deployer
+Enter the JumpCloud SSO URL for duff-deployer: <url copied from the JumpCloud Console>
+Profile duff-deployer added.
+```
+
+You can specify the assumed role by name or ARN, which allows you to assume a role in another AWS account:
+
+```
+$ aws-jumpcloud add --role=arn:aws:iam::619893369699:role/deployer subaccount-deployer
+Enter the JumpCloud SSO URL for subaccount-deployer: <url copied from the JumpCloud Console>
+Profile duff-deployer added.
+```
+
+If the role requires an External ID to be provided to the AssumeRole API, that must be specified when creating the `aws-jumpcloud` profile, using the `--external-id` parameter. For example:
+
+```
+$ aws-jumpcloud add --role=deployer --external-id=QgbnxwqT2w duff-deployer
+Enter the JumpCloud SSO URL for duff-deployer: <url copied from the JumpCloud Console>
+Profile duff-deployer added.
+```
+
+The AWS IAM User Guide contains [more information about assuming IAM roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html).
+
+
 ### Rotating credentials
 
 After a profile's temporary IAM credentials expire, `aws-jumpcloud` will automatically delete the credentials from its keychain. New temporary credentials will automatically be requested the next time you attempt to use that profile. However, you can also rotate the credentials at any time and request new credentials immediately.

--- a/aws_jumpcloud/cli.py
+++ b/aws_jumpcloud/cli.py
@@ -54,6 +54,10 @@ def _add_add_command(p):
     parser_add = p.add_parser("add", help="add a new profile")
     parser_add.add_argument("profile", help="name of the profile")
     parser_add.add_argument("url", help="JumpCloud SSO URL for this profile", nargs="?")
+    parser_add.add_argument("-r", "--role", help="IAM role to assume after login (name or ARN)",
+                            dest="role_to_assume", metavar="ROLE")
+    parser_add.add_argument("--external-id", help="External ID to provide when assuming a role after login",
+                            metavar="ID")
     parser_add.set_defaults(func=commands.add_profile)
 
 

--- a/aws_jumpcloud/cli.py
+++ b/aws_jumpcloud/cli.py
@@ -53,6 +53,7 @@ def _add_list_command(p):
 def _add_add_command(p):
     parser_add = p.add_parser("add", help="add a new profile")
     parser_add.add_argument("profile", help="name of the profile")
+    parser_add.add_argument("url", help="JumpCloud SSO URL for this profile", nargs="?")
     parser_add.set_defaults(func=commands.add_profile)
 
 

--- a/aws_jumpcloud/commands.py
+++ b/aws_jumpcloud/commands.py
@@ -49,7 +49,8 @@ def add_profile(args):
                      "the profile, remove the profile and add it again.")
         sys.exit(1)
 
-    jumpcloud_url = input(f"Enter the JumpCloud SSO URL for \"{args.profile}\": ").strip()
+    jumpcloud_url = args.url or input(f"Enter the JumpCloud SSO URL for \"{args.profile}\": ")
+    jumpcloud_url = jumpcloud_url.strip()
     if not jumpcloud_url.startswith("https://sso.jumpcloud.com/saml2/"):
         _print_error("Error: That's not a valid JumpCloud SSO URL. SSO URLs must "
                      "start with \"https://sso.jumpcloud.com/saml2/\".")

--- a/aws_jumpcloud/profile.py
+++ b/aws_jumpcloud/profile.py
@@ -1,26 +1,30 @@
 import json
 
+from aws_jumpcloud.aws import build_arn, parse_arn
+
 
 class Profile(object):
-    def __init__(self, name, jumpcloud_url):
+    def __init__(self, name, jumpcloud_url, role_to_assume=None):
         self.name = name
         self.jumpcloud_url = jumpcloud_url
         self.aws_account_id = None
         self.aws_role = None
         self.aws_account_alias = None
+        self.role_to_assume = role_to_assume
 
     @property
     def role_arn(self):
         assert(self.aws_account_id is not None)
         assert(self.aws_role is not None)
-        return f"arn:aws:iam::{self.aws_account_id}:role/{self.aws_role}"
+        return build_arn(self.aws_account_id, self.aws_role)
 
     def dumps(self):
         return json.dumps({"name": self.name,
                            "jumpcloud_url": self.jumpcloud_url,
                            "aws_account_id": self.aws_account_id,
                            "aws_account_alias": self.aws_account_alias,
-                           "aws_role": self.aws_role})
+                           "aws_role": self.aws_role,
+                           "role_to_assume": self.role_to_assume.dumps() if self.role_to_assume else None})
 
     @classmethod
     def loads(cls, json_string):
@@ -29,4 +33,30 @@ class Profile(object):
         p.aws_account_id = data['aws_account_id']
         p.aws_role = data['aws_role']
         p.aws_account_alias = data['aws_account_alias']
+        if data.get('role_to_assume') is not None:
+            p.role_to_assume = AssumedRole.loads(data['role_to_assume'])
         return p
+
+
+class AssumedRole(object):
+    def __init__(self, aws_account_id, aws_role, external_id):
+        self.aws_account_id = aws_account_id
+        self.aws_role = aws_role
+        self.external_id = external_id
+
+    @property
+    def arn(self):
+        if self.aws_account_id:
+            return build_arn(self.aws_account_id, self.aws_role)
+        else:
+            return None
+
+    def dumps(self):
+        return json.dumps({"aws_account_id": self.aws_account_id,
+                           "aws_role": self.aws_role,
+                           "external_id": self.external_id})
+
+    @classmethod
+    def loads(cls, json_string):
+        data = json.loads(json_string)
+        return AssumedRole(**data)


### PR DESCRIPTION
Allows the user to add a profile without user interaction -- makes it easier for us to write documentation or add the `aws-jumpcloud add` command to scripts.

```
[ryan@MacBook:~]$ aws-jumpcloud add guild-staging https://sso.jumpcloud.com/saml2/awsjumpcloudadmins
Profile "guild-staging" added.
```

Still works the old way too:

```
[ryan@MacBook:~]$ aws-jumpcloud add guild-staging 
Enter the JumpCloud SSO URL for "guild-staging": https://sso.jumpcloud.com/saml2/awsjumpcloudadmins
Profile "guild-staging" added.
```