### PR TITLE
Automatically use 1Password credentials if CLI installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ Attempting SSO authentication to Amazon Web Services...
 AWS temporary session rotated; new session valid until Thu Nov 15 20:49:38 2018 UTC.
 ```
 
+### 1Password support
+
+If the [1Password CLI](https://1password.com/downloads/command-line/) is installed, `aws-jumpcloud` will automatically use your JumpCloud credentials and MFA token from 1Password. The credentials must be stored in an item named `jumpcloud`
+
 
 ## Developing
 

--- a/aws_jumpcloud/onepassword.py
+++ b/aws_jumpcloud/onepassword.py
@@ -1,0 +1,34 @@
+from shutil import which
+import os
+import json
+
+ITEM = "jumpcloud"
+
+
+def installed():
+    return which("op") is not None
+
+
+def get_email():
+    return _get_field("email")
+
+
+def get_password():
+    return _get_field("password")
+
+
+def _get_field(field):
+    fields = _get_item()['details']['fields']
+    return next(item.get('value') for item in fields if item.get('name') == field)
+
+
+def _get_item():
+    return json.loads(_cmd(f"get item {ITEM}"))
+
+
+def get_totp():
+    return _cmd("get totp")
+
+
+def _cmd(cmd):
+    return os.popen(f'op {cmd} {ITEM}').read().strip()


### PR DESCRIPTION
- Use 1Password-stored OTP for `jumpcloud` item if configured, fall back to user input
- Use 1Password-stored `jumpcloud` email address and password
- Update readme