### PR TITLE
Edits to 1Password description

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,14 +204,15 @@ your shell, add the following to your `.(bash|zsh|whatever)rc`
 ```bash
 aws-jumpcloud-rotate() {
   if [ "$(aws-jumpcloud is-expired $1)" = "1" ]; then
-    eval $(op signin guild_education)
+    eval $(op signin duff-beer)
     aws-jumpcloud rotate $1
   fi
 }
 
-aws-jumpcloud-rotate guild-dev
+aws-jumpcloud-rotate duff
 ```
 
+The "duff-beer" refers to the [subdomain](https://support.1password.com/command-line/) of your 1Password acount (e.g., the "duff-beer" of your "duff-beer.1password.com" 1Password account).
 
 ## Developing
 


### PR DESCRIPTION
Very fired up about the new 1Password integration!!!

I've tried to make the description a little clearer.  I removed "guild-education" and "guild-dev", and added a subdomain name and profile name consistent with your earlier examples.

Any chance that y'all might tweak this implementation so that the item name isn't *required* to be "jumpcloud"?  :)

Thanks for the hard work!