### PR TITLE
Fix for TypeError when there is no active session

### DIFF
--- a/aws_jumpcloud/commands.py
+++ b/aws_jumpcloud/commands.py
@@ -364,7 +364,7 @@ def _format_profile_rows(profiles, sessions):
         if p.role_to_assume:
             aws_role = p.role_to_assume.aws_role
         else:
-            aws_role = p.aws_role
+            aws_role = p.aws_role or "<unknown>"
         if p.name in sessions:
             expires_at = sessions[p.name].expires_at.astimezone().strftime("%c %Z")
         else:


### PR DESCRIPTION
aws_role is None when you've created a profile but haven't actually logged in with it.