### PR TITLE
is-expired is not available, using is-active instead for rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ your shell, add the following to your `.(bash|zsh|whatever)rc`
 
 ```bash
 aws-jumpcloud-rotate() {
-  if [ "$(aws-jumpcloud is-expired $1)" = "1" ]; then
+  if [ "$(aws-jumpcloud is-active $1)" != "1" ]; then
     eval $(op signin duff-beer)
     aws-jumpcloud rotate $1
   fi


### PR DESCRIPTION
`is-expired` is not available for `aws-jumpcloud`, using `is-active` instead for this purpose.