### PR TITLE
Corrects detection for 1Password CLI

### DIFF
--- a/aws_jumpcloud/onepassword.py
+++ b/aws_jumpcloud/onepassword.py
@@ -8,7 +8,7 @@ ITEM = "jumpcloud"
 
 
 def installed():
-    hasop = which("op") is not None
+    hasop = which("op") is not None and which("op") is not True
     if hasop:
         if os.getenv('OP_SUBDOMAIN') and subprocess.call("op get account", shell=True):  # returns truthy non-zero exit code if no active op CLI session
             subprocess.check_call("eval $(op signin $OP_SUBDOMAIN)", shell=True)


### PR DESCRIPTION
This came up because I do not have op (1Password CLI) installed and prefer to use the phone/OTP method for MFA.

For some reason my system returns True when a command is not found by which. Either way this fixes the issue.