### PR TITLE
op.installed => op.installed() 

### DIFF
--- a/aws_jumpcloud/jumpcloud.py
+++ b/aws_jumpcloud/jumpcloud.py
@@ -31,7 +31,7 @@ class JumpCloudSession(object):
                 raise e
 
     def _get_mfa(self):
-        if op.installed:
+        if op.installed():
             sys.stderr.write(f"1Password CLI found. Using OTP from item: {op.ITEM}\n")
             mfa = op.get_totp()
 


### PR DESCRIPTION
* Need to execute the call for if statement to work correctly
* op.installed is a reference to the function, op.installed() calls the function which is what we want in this case.

* the new version 2.1.4 was giving me the same error as before if I did not have `op` installed.