### PR TITLE
Changing codeowners to DevOps team from individual users

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @javs-perez @qhartman @treyx
+* @GuildEducationInc/DevOps


### PR DESCRIPTION
I think this is the right approach in order to use specific Guild team as a codeowner. 